### PR TITLE
fix: 修复地点搜索返回结果未过滤不含坐标值的问题

### DIFF
--- a/src/components/LocationSearch/index.tsx
+++ b/src/components/LocationSearch/index.tsx
@@ -42,7 +42,7 @@ export const LocationSearch: React.FC<LocationSearchProps> = ({
         setIsLoading(false);
       });
       setOptions(
-        (res?.tips ?? []).map((item) => {
+        (res?.tips ?? []).filter(item => item.location && item.location.length).map((item) => {
           const [lon, lat] = item.location.split(',');
           item.longitude = +lon;
           item.latitude = +lat;


### PR DESCRIPTION
高德API在返回城市时不含坐标值，不过滤的话会有异常

### PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

- [ ] fixed #0
- [ ] add / modify test cases
- [ ] documents, demos

### Screenshot
<img width="676" alt="image" src="https://user-images.githubusercontent.com/33211377/191484235-06da4351-c61f-434b-811f-f9849f9d6cca.png">
<img width="417" alt="image" src="https://user-images.githubusercontent.com/33211377/191484315-22c6015b-8297-4086-b791-6b481b96c8b7.png">

| Before | After |
| ------ | ----- |
| ❌     | ✅    |
