### PR TITLE
feat: 新增地图状态同步方法 syncScene

### DIFF
--- a/docs/example/syncScene.md
+++ b/docs/example/syncScene.md
@@ -1,6 +1,6 @@
 ---
 toc: false
-order: 10
+order: 1
 nav:
   title: 示例
   path: /example
@@ -11,9 +11,9 @@ nav:
 
 ## 介绍
 
-地图同步状态工具函数
+用于同步地图状态「缩放层级和地图中心」的方法。
 
-地图类型 支持 Gaode 和 Mapbox
+支持 Gaode 和 Mapbox 两种地图类型
 
 ### 使用场景
 
@@ -24,6 +24,7 @@ nav:
 ### 示例一：基础使用
 
 ```tsx
+import type { Scene } from '@antv/l7';
 import type { LarkMapProps } from '@antv/larkmap';
 import { LarkMap, syncScene } from '@antv/larkmap';
 import React from 'react';
@@ -37,13 +38,13 @@ const config: LarkMapProps = {
 };
 export default () => {
   const [sceneArray, setSceneArray] = React.useState([]);
-  const clearRef = React.useRef();
+  const clearRef = React.useRef<() => void>();
   const onSceneLoaded = (scene: Scene) => {
     setSceneArray((oldValue) => [...oldValue, scene]);
   };
 
   const clearSync = () => {
-    clearRef.current();
+    if (clearRef.current) clearRef.current();
   };
   const addSync = () => {
     clearRef.current = syncScene(sceneArray);
@@ -52,9 +53,7 @@ export default () => {
   return (
     <div>
       <button onClick={addSync}>添加场景同步</button>
-
       <button onClick={clearSync}>清除同步</button>
-
       <div style={{ display: 'flex', flexDirection: 'row', height: '300px' }}>
         <LarkMap onSceneLoaded={onSceneLoaded} {...config} id="scene" style={{ flex: 1 }}>
           <h2 style={{ position: 'absolute', left: '10px' }}>地图1</h2>
@@ -71,8 +70,10 @@ export default () => {
 ### 示例二： 设置 zoomGap
 
 ```tsx
+import type { Scene } from '@antv/l7';
 import type { LarkMapProps } from '@antv/larkmap';
 import { LarkMap, syncScene } from '@antv/larkmap';
+
 import React from 'react';
 const config: LarkMapProps = {
   // mapType: 'Gaode',
@@ -84,12 +85,14 @@ const config: LarkMapProps = {
 };
 export default () => {
   const [sceneArray, setSceneArray] = React.useState([]);
-  const [zoomGap, setZoomGap] = React.useState(0);
+  const [zoomGap, setZoomGap] = React.useState<Number>();
   const onSceneLoaded = (scene: Scene) => {
     setSceneArray((oldValue) => [...oldValue, scene]);
   };
   const changeHandler = (e) => {
-    setZoomGap(e.target.value);
+    // 转为Number类型
+    const gap = Number(e.target.value);
+    setZoomGap(gap);
   };
   React.useEffect(() => {
     const callback = syncScene(sceneArray, {
@@ -106,7 +109,7 @@ export default () => {
       设置zoomGap： <input onChange={changeHandler}></input>
       <div style={{ display: 'flex', flexDirection: 'row', height: '300px' }}>
         <LarkMap onSceneLoaded={onSceneLoaded} {...config} id="scene" style={{ flex: 1 }}>
-          <h2 style={{ position: 'absolute', left: '10px' }}>地图1</h2>
+          <h2 style={{ position: 'absolute', left: '10px' }}>主地图</h2>
         </LarkMap>
         <LarkMap onSceneLoaded={onSceneLoaded} {...config} id="scene2" style={{ flex: 1 }}>
           <h2 style={{ position: 'absolute', left: '10px' }}>地图2</h2>
@@ -119,17 +122,17 @@ export default () => {
 
 ## API
 
-方法：syncScene(sceneArray,option)
+方法：`syncScene(sceneArray,option)`
 
 ### sceneArray
 
-L7.Scene 的数组
+`L7.Scene` 的数组
 
 ### options
 
-| 参数           | 说明                                                                 | 类型   | 默认值 |
-| -------------- | -------------------------------------------------------------------- | ------ | ------ |
-| zoomGap        | 用于设置同步场景的地图层级差                                         | number | 0      |
-| mainSceneIndex | 搭配 zoomGap 使用，用于设置主场景，其余场景为主场景的 zoom + zoomGap | number | 0      |
+| 参数        | 说明                                                                       | 类型     | 默认值 |
+| ----------- | -------------------------------------------------------------------------- | -------- | ------ |
+| `zoomGap`   | 用于设置同步场景的地图层级差                                               | `number` | 0      |
+| `mainIndex` | 搭配 `zoomGap` 使用，用于设置主场景，其余场景为主场景的 `zoom` + `zoomGap` | `number` | 0      |
 
 ## FAQ

--- a/docs/example/syncScene.md
+++ b/docs/example/syncScene.md
@@ -1,0 +1,135 @@
+---
+toc: false
+order: 10
+nav:
+  title: 示例
+  path: /example
+  order: 3
+---
+
+# 同步地图 - syncScene
+
+## 介绍
+
+地图同步状态工具函数
+
+地图类型 支持 Gaode 和 Mapbox
+
+### 使用场景
+
+可用于同步两个场景的地图状态，适用于 两幅地图的联动。
+
+## 代码演示
+
+### 示例一：基础使用
+
+```tsx
+import type { LarkMapProps } from '@antv/larkmap';
+import { LarkMap, syncScene } from '@antv/larkmap';
+import React from 'react';
+const config: LarkMapProps = {
+  // mapType: 'Gaode',
+  mapOptions: {
+    style: 'light',
+    center: [120.210792, 30.246026],
+    zoom: 9,
+  },
+};
+export default () => {
+  const [sceneArray, setSceneArray] = React.useState([]);
+  const clearRef = React.useRef();
+  const onSceneLoaded = (scene: Scene) => {
+    setSceneArray((oldValue) => [...oldValue, scene]);
+  };
+
+  const clearSync = () => {
+    clearRef.current();
+  };
+  const addSync = () => {
+    clearRef.current = syncScene(sceneArray);
+  };
+
+  return (
+    <div>
+      <button onClick={addSync}>添加场景同步</button>
+
+      <button onClick={clearSync}>清除同步</button>
+
+      <div style={{ display: 'flex', flexDirection: 'row', height: '300px' }}>
+        <LarkMap onSceneLoaded={onSceneLoaded} {...config} id="scene" style={{ flex: 1 }}>
+          <h2 style={{ position: 'absolute', left: '10px' }}>地图1</h2>
+        </LarkMap>
+        <LarkMap onSceneLoaded={onSceneLoaded} {...config} id="scene2" style={{ flex: 1 }}>
+          <h2 style={{ position: 'absolute', left: '10px' }}>地图2</h2>
+        </LarkMap>
+      </div>
+    </div>
+  );
+};
+```
+
+### 示例二： 设置 zoomGap
+
+```tsx
+import type { LarkMapProps } from '@antv/larkmap';
+import { LarkMap, syncScene } from '@antv/larkmap';
+import React from 'react';
+const config: LarkMapProps = {
+  // mapType: 'Gaode',
+  mapOptions: {
+    style: 'light',
+    center: [120.210792, 30.246026],
+    zoom: 9,
+  },
+};
+export default () => {
+  const [sceneArray, setSceneArray] = React.useState([]);
+  const [zoomGap, setZoomGap] = React.useState(0);
+  const onSceneLoaded = (scene: Scene) => {
+    setSceneArray((oldValue) => [...oldValue, scene]);
+  };
+  const changeHandler = (e) => {
+    setZoomGap(e.target.value);
+  };
+  React.useEffect(() => {
+    const callback = syncScene(sceneArray, {
+      zoomGap,
+      mainSceneIndex: 0,
+    });
+    return () => {
+      callback();
+    };
+  }, [zoomGap]);
+
+  return (
+    <div>
+      设置zoomGap： <input onChange={changeHandler}></input>
+      <div style={{ display: 'flex', flexDirection: 'row', height: '300px' }}>
+        <LarkMap onSceneLoaded={onSceneLoaded} {...config} id="scene" style={{ flex: 1 }}>
+          <h2 style={{ position: 'absolute', left: '10px' }}>地图1</h2>
+        </LarkMap>
+        <LarkMap onSceneLoaded={onSceneLoaded} {...config} id="scene2" style={{ flex: 1 }}>
+          <h2 style={{ position: 'absolute', left: '10px' }}>地图2</h2>
+        </LarkMap>
+      </div>
+    </div>
+  );
+};
+```
+
+## API
+
+方法：syncScene(sceneArray,option)
+
+### sceneArray
+
+L7.Scene 的数组
+
+### options
+
+| 参数           | 说明                                                                 | 类型   | 默认值 |
+| -------------- | -------------------------------------------------------------------- | ------ | ------ |
+| zoomGap        | 用于设置同步场景的地图层级差                                         | number | 0      |
+| mainSceneIndex | 搭配 zoomGap 使用，用于设置主场景，其余场景为主场景的 zoom + zoomGap | number | 0      |
+
+## FAQ

--- a/docs/example/syncScene.md
+++ b/docs/example/syncScene.md
@@ -17,7 +17,7 @@ nav:
 
 ### 使用场景
 
-可用于同步两个场景的地图状态，适用于 两幅地图的联动。
+适用于同步两个场景的地图状态，适用于两幅或多幅地图的联动。
 
 ## 代码演示
 
@@ -122,7 +122,7 @@ export default () => {
 
 ## API
 
-` syncScene(scenes: Scene[], options: { zoomGap: number, mainIndex: number }) `
+`syncScene(scenes: Scene[], options: { zoomGap: number, mainIndex: number })`
 
 ### scenes
 

--- a/docs/example/syncScene.md
+++ b/docs/example/syncScene.md
@@ -55,10 +55,10 @@ export default () => {
       <button onClick={addSync}>添加场景同步</button>
       <button onClick={clearSync}>清除同步</button>
       <div style={{ display: 'flex', flexDirection: 'row', height: '300px' }}>
-        <LarkMap onSceneLoaded={onSceneLoaded} {...config} id="scene" style={{ flex: 1 }}>
+        <LarkMap onSceneLoaded={onSceneLoaded} {...config} id="baseScene" style={{ flex: 1 }}>
           <h2 style={{ position: 'absolute', left: '10px' }}>地图1</h2>
         </LarkMap>
-        <LarkMap onSceneLoaded={onSceneLoaded} {...config} id="scene2" style={{ flex: 1 }}>
+        <LarkMap onSceneLoaded={onSceneLoaded} {...config} id="baseScene2" style={{ flex: 1 }}>
           <h2 style={{ position: 'absolute', left: '10px' }}>地图2</h2>
         </LarkMap>
       </div>
@@ -108,10 +108,10 @@ export default () => {
     <div>
       设置zoomGap： <input onChange={changeHandler}></input>
       <div style={{ display: 'flex', flexDirection: 'row', height: '300px' }}>
-        <LarkMap onSceneLoaded={onSceneLoaded} {...config} id="scene" style={{ flex: 1 }}>
+        <LarkMap onSceneLoaded={onSceneLoaded} {...config} id="gapScene" style={{ flex: 1 }}>
           <h2 style={{ position: 'absolute', left: '10px' }}>主地图</h2>
         </LarkMap>
-        <LarkMap onSceneLoaded={onSceneLoaded} {...config} id="scene2" style={{ flex: 1 }}>
+        <LarkMap onSceneLoaded={onSceneLoaded} {...config} id="gapScene2" style={{ flex: 1 }}>
           <h2 style={{ position: 'absolute', left: '10px' }}>地图2</h2>
         </LarkMap>
       </div>
@@ -120,7 +120,57 @@ export default () => {
 };
 ```
 
-### 示例三：多地图场景同步
+### 示例三：不同引擎
+
+```tsx
+import type { Scene } from '@antv/l7';
+import type { LarkMapProps } from '@antv/larkmap';
+import { LarkMap, syncScene } from '@antv/larkmap';
+import React from 'react';
+const config: LarkMapProps = {
+  mapOptions: {
+    style: 'light',
+    center: [120.210792, 30.246026],
+    zoom: 9,
+  },
+};
+export default () => {
+  const [sceneArray, setSceneArray] = React.useState([]);
+  const [mapType, setMapType] = React.useState();
+  const onSceneLoaded = (scene: Scene) => {
+    setSceneArray((oldValue) => [...oldValue, scene]);
+  };
+  const changeMapType = (e) => {
+    setMapType(e.target.value);
+  };
+
+  React.useEffect(() => {
+    const callback = syncScene(sceneArray);
+    return callback;
+  }, [sceneArray]);
+
+  return (
+    <div>
+      <select onChange={changeMapType}>
+        <option value="Mapbox">Mapbox</option>
+        <option value="Gaode" selected>
+          Gaode
+        </option>
+      </select>
+      <div style={{ display: 'flex', flexDirection: 'row', height: '300px' }}>
+        <LarkMap onSceneLoaded={onSceneLoaded} {...config} mapType={mapType} id="engineScene" style={{ flex: 1 }}>
+          <h2 style={{ position: 'absolute', left: '10px' }}>地图1</h2>
+        </LarkMap>
+        <LarkMap onSceneLoaded={onSceneLoaded} {...config} mapType={mapType} id="engineScene2" style={{ flex: 1 }}>
+          <h2 style={{ position: 'absolute', left: '10px' }}>地图2</h2>
+        </LarkMap>
+      </div>
+    </div>
+  );
+};
+```
+
+### 示例四：多地图场景同步
 
 ```tsx
 import type { Scene } from '@antv/l7';
@@ -158,16 +208,16 @@ export default () => {
       <button onClick={addSync}>添加场景同步</button>
       <button onClick={clearSync}>清除同步</button>
       <div style={{ display: 'flex', flexDirection: 'row', height: '400px' }}>
-        <LarkMap onSceneLoaded={onSceneLoaded} {...config} id="scene" style={{ flex: 1 }}>
+        <LarkMap onSceneLoaded={onSceneLoaded} {...config} id="multiScene" style={{ flex: 1 }}>
           <h3 style={{ position: 'absolute', left: '10px' }}>主地图</h3>
         </LarkMap>
-        <LarkMap onSceneLoaded={onSceneLoaded} {...config} id="scene2" style={{ flex: 1 }}>
+        <LarkMap onSceneLoaded={onSceneLoaded} {...config} id="multiScene2" style={{ flex: 1 }}>
           <h3 style={{ position: 'absolute', left: '10px' }}>地图2</h3>
         </LarkMap>
-        <LarkMap onSceneLoaded={onSceneLoaded} {...config} id="scene2" style={{ flex: 1 }}>
+        <LarkMap onSceneLoaded={onSceneLoaded} {...config} id="multiScene3" style={{ flex: 1 }}>
           <h3 style={{ position: 'absolute', left: '10px' }}>地图3</h3>
         </LarkMap>
-        <LarkMap onSceneLoaded={onSceneLoaded} {...config} id="scene2" style={{ flex: 1 }}>
+        <LarkMap onSceneLoaded={onSceneLoaded} {...config} id="multiScene4" style={{ flex: 1 }}>
           <h3 style={{ position: 'absolute', left: '10px' }}>地图4</h3>
         </LarkMap>
       </div>

--- a/docs/example/syncScene.md
+++ b/docs/example/syncScene.md
@@ -11,13 +11,13 @@ nav:
 
 ## 介绍
 
-用于同步地图状态「缩放层级和地图中心」的方法。
+用于同步地图状态「缩放层级、地图中心点、旋转角、倾斜角」。
 
-支持 Gaode 和 Mapbox 两种地图类型
+支持 Gaode 和 Mapbox 两种地图引擎类型
 
 ### 使用场景
 
-适用于同步两个场景的地图状态，适用于两幅或多幅地图的联动。
+适用于同步多个场景的地图状态，适用于两幅或多幅地图的联动。
 
 ## 代码演示
 
@@ -163,6 +163,9 @@ export default () => {
 ### 示例四：多地图场景同步
 
 ```tsx
+/**
+ * title: 主地图与其余地图缩放层级差为2
+ */
 import type { Scene } from '@antv/l7';
 import type { LarkMapProps } from '@antv/larkmap';
 import { LarkMap, syncScene } from '@antv/larkmap';
@@ -194,7 +197,7 @@ export default () => {
 
   return (
     <div>
-      <h2>设置主地图与其余地图缩放层级差为2</h2>
+      <h1>主地图与其余地图缩放层级差为2</h1>
       <button onClick={addSync}>添加场景同步</button>
       <button onClick={clearSync}>清除同步</button>
       <div style={{ display: 'flex', flexDirection: 'row', height: '400px' }}>
@@ -206,9 +209,6 @@ export default () => {
         </LarkMap>
         <LarkMap onSceneLoaded={onSceneLoaded} {...config} id="multiScene3" style={{ flex: 1 }}>
           <h3 style={{ position: 'absolute', left: '10px' }}>地图3</h3>
-        </LarkMap>
-        <LarkMap onSceneLoaded={onSceneLoaded} {...config} id="multiScene4" style={{ flex: 1 }}>
-          <h3 style={{ position: 'absolute', left: '10px' }}>地图4</h3>
         </LarkMap>
       </div>
     </div>

--- a/docs/example/syncScene.md
+++ b/docs/example/syncScene.md
@@ -120,6 +120,62 @@ export default () => {
 };
 ```
 
+### 示例三：多地图场景同步
+
+```tsx
+import type { Scene } from '@antv/l7';
+import type { LarkMapProps } from '@antv/larkmap';
+import { LarkMap, syncScene } from '@antv/larkmap';
+import React from 'react';
+const config: LarkMapProps = {
+  mapType: 'Gaode',
+  mapOptions: {
+    style: 'light',
+    center: [120.210792, 30.246026],
+    zoom: 9,
+  },
+};
+export default () => {
+  const [sceneArray, setSceneArray] = React.useState([]);
+  const clearRef = React.useRef<() => void>();
+  const onSceneLoaded = (scene: Scene) => {
+    setSceneArray((oldValue) => [...oldValue, scene]);
+  };
+
+  const clearSync = () => {
+    if (clearRef.current) clearRef.current();
+  };
+  const addSync = () => {
+    clearRef.current = syncScene(sceneArray, {
+      zoomGap: 2,
+      mainIndex: 0,
+    });
+  };
+
+  return (
+    <div>
+      <h2>设置主地图与其余地图缩放层级差为2</h2>
+      <button onClick={addSync}>添加场景同步</button>
+      <button onClick={clearSync}>清除同步</button>
+      <div style={{ display: 'flex', flexDirection: 'row', height: '400px' }}>
+        <LarkMap onSceneLoaded={onSceneLoaded} {...config} id="scene" style={{ flex: 1 }}>
+          <h3 style={{ position: 'absolute', left: '10px' }}>主地图</h3>
+        </LarkMap>
+        <LarkMap onSceneLoaded={onSceneLoaded} {...config} id="scene2" style={{ flex: 1 }}>
+          <h3 style={{ position: 'absolute', left: '10px' }}>地图2</h3>
+        </LarkMap>
+        <LarkMap onSceneLoaded={onSceneLoaded} {...config} id="scene2" style={{ flex: 1 }}>
+          <h3 style={{ position: 'absolute', left: '10px' }}>地图3</h3>
+        </LarkMap>
+        <LarkMap onSceneLoaded={onSceneLoaded} {...config} id="scene2" style={{ flex: 1 }}>
+          <h3 style={{ position: 'absolute', left: '10px' }}>地图4</h3>
+        </LarkMap>
+      </div>
+    </div>
+  );
+};
+```
+
 ## API
 
 `syncScene(scenes: Scene[], options: { zoomGap: number, mainIndex: number })`

--- a/docs/example/syncScene.md
+++ b/docs/example/syncScene.md
@@ -120,7 +120,7 @@ export default () => {
 };
 ```
 
-### 示例三：不同引擎
+### 示例三：Mapbox 引擎
 
 ```tsx
 import type { Scene } from '@antv/l7';
@@ -136,12 +136,8 @@ const config: LarkMapProps = {
 };
 export default () => {
   const [sceneArray, setSceneArray] = React.useState([]);
-  const [mapType, setMapType] = React.useState();
   const onSceneLoaded = (scene: Scene) => {
     setSceneArray((oldValue) => [...oldValue, scene]);
-  };
-  const changeMapType = (e) => {
-    setMapType(e.target.value);
   };
 
   React.useEffect(() => {
@@ -151,17 +147,11 @@ export default () => {
 
   return (
     <div>
-      <select onChange={changeMapType}>
-        <option value="Mapbox">Mapbox</option>
-        <option value="Gaode" selected>
-          Gaode
-        </option>
-      </select>
       <div style={{ display: 'flex', flexDirection: 'row', height: '300px' }}>
-        <LarkMap onSceneLoaded={onSceneLoaded} {...config} mapType={mapType} id="engineScene" style={{ flex: 1 }}>
+        <LarkMap onSceneLoaded={onSceneLoaded} {...config} mapType="Mapbox" id="engineScene" style={{ flex: 1 }}>
           <h2 style={{ position: 'absolute', left: '10px' }}>地图1</h2>
         </LarkMap>
-        <LarkMap onSceneLoaded={onSceneLoaded} {...config} mapType={mapType} id="engineScene2" style={{ flex: 1 }}>
+        <LarkMap onSceneLoaded={onSceneLoaded} {...config} mapType="Mapbox" id="engineScene2" style={{ flex: 1 }}>
           <h2 style={{ position: 'absolute', left: '10px' }}>地图2</h2>
         </LarkMap>
       </div>

--- a/docs/example/syncScene.md
+++ b/docs/example/syncScene.md
@@ -122,11 +122,11 @@ export default () => {
 
 ## API
 
-方法：`syncScene(sceneArray,option)`
+` syncScene(scenes: Scene[], options: { zoomGap: number, mainIndex: number }) `
 
-### sceneArray
+### scenes
 
-`L7.Scene` 的数组
+LarkMap 加载完成的 Scene 实例数组
 
 ### options
 
@@ -134,5 +134,3 @@ export default () => {
 | ----------- | -------------------------------------------------------------------------- | -------- | ------ |
 | `zoomGap`   | 用于设置同步场景的地图层级差                                               | `number` | 0      |
 | `mainIndex` | 搭配 `zoomGap` 使用，用于设置主场景，其余场景为主场景的 `zoom` + `zoomGap` | `number` | 0      |
-
-## FAQ

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,10 +3,7 @@
  * 容器组件
  */
 export { LarkMap } from './components/LarkMap';
-export type {
-  LarkMapProps,
-  LarkMapRefAttributes,
-} from './components/LarkMap/types';
+export type { LarkMapProps, LarkMapRefAttributes } from './components/LarkMap/types';
 export * from './components/LarkMap/hooks';
 
 /**
@@ -68,3 +65,4 @@ export * from './components/LayerAttribute';
  * 版本号
  */
 export { default as version } from './version';
+export { syncScene } from './utils/syncScene';

--- a/src/utils/syncScene.ts
+++ b/src/utils/syncScene.ts
@@ -1,7 +1,7 @@
 /*
- * @name         : 地图同步方法
+ * @name         : 地图状态同步方法
  * @Description  : 用于将多个地图动作、视角同步
- * @Principle    : 监听所有地图场景的 mapmove 与zoomChange 事件。触发时，解绑自己事件 => 同步所有的地图状态 => 重新添加监听
+ * @Principle    : 监听所有地图场景的 mapmove、zoomchange、rotate 等事件。触发时，解绑自己事件 => 同步所有的地图状态 => 重新添加监听
  */
 
 import type { Scene } from '@antv/l7';
@@ -40,14 +40,14 @@ const updateSceneStatus = (
   } else {
     if (zoom) scene?.setZoom(zoom);
     if (center) scene?.setCenter(center);
-    // if (rotation) scene?.setRotation(rotation);
+    if (rotation) scene.setRotation(rotation);
     if (pitch) scene?.setPitch(pitch);
   }
 };
 
 /**
  *
- * @param scenes l7实例化的scene 的数组
+ * @param scenes l7实例化的 scene 的数组
  * @param options
  * @param options.zoomGap number  同步的缩放层级差距
  * @param options.mainIndex number  主场景的数组索引，用于搭配 zoomGap
@@ -71,13 +71,14 @@ export function syncScene(
     // Gaode 地图调整倾角和旋转角的事件
     scene.on('dragging', handlers[index]);
     // Mapbox 地图调整倾角和旋转角的事件
-    scene.on('drag', handlers[index]);
+    scene.on('rotate', handlers[index]);
     scene.on('zoomchange', handlers[index]);
+
     return () => {
       scene.off('mapmove', handlers[index]);
       scene.off('dragging', handlers[index]);
       scene.off('zoomchange', handlers[index]);
-      scene.on('drag', handlers[index]);
+      scene.off('rotate', handlers[index]);
     };
   };
 

--- a/src/utils/syncScene.ts
+++ b/src/utils/syncScene.ts
@@ -1,37 +1,41 @@
 /*
  * @name         : 地图同步方法
  * @Description  : 用于将多个地图动作、视角同步
- * @Principle    : 自身发送事件后，解绑自己事件，再重新添加监听
+ * @Principle    : 监听所有地图的move事件，触发时，先解绑自己事件，在同步所有的地图状态。再重新添加监听
  */
 
 import type { Scene } from '@antv/l7';
-type Instance = Scene;
-export function getMapType(scene: Scene) {
+
+// 通过Scene获取到地图引擎类型
+function getMapType(scene: Scene) {
   const mapVersion = scene.getMapService().version;
-  return mapVersion?.includes('MAPBOX') ? 'mapbox' : 'gaode';
+  return mapVersion?.includes('MAPBOX') ? 'Mapbox' : 'Gaode';
 }
 
+// 根据不同地图引擎类型，设置地图的缩放层级
 function setZoom(scene: Scene, zoom: number): void {
   const mapType = getMapType(scene);
-  if (mapType === 'gaode') {
-    // 高德地图必须关闭动画效果，否则无法实现联动
-    //L7 针对Gao，进行的zoom+ 1 的操作
+  if (mapType === 'Gaode') {
+    /**
+     * NOTE: 高德地图必须关闭动画效果，否则无法实现联动
+     *       L7 针对Gaode地图，进行的zoom + 1 的操作
+     */
     //@ts-ignore
     scene?.map?.setZoom(zoom + 1, true);
   } else {
-    //@ts-ignore
-    scene?.map?.setZoom(zoom);
+    scene.setZoom(zoom);
   }
 }
 
+// 根据不同地图引擎类型，设置地图的中心点
 function setCenter(scene: Scene, center: [number, number]) {
   const mapType = getMapType(scene);
-  if (mapType === 'gaode') {
+  if (mapType === 'Gaode') {
+    // 同setZoom，高德地图关闭设置center的动画效果
     //@ts-ignore
     scene?.map.setCenter(center, true);
   } else {
-    //@ts-ignore
-    scene?.map.setCenter(center);
+    scene?.setCenter(center);
   }
 }
 
@@ -40,31 +44,45 @@ function setCenter(scene: Scene, center: [number, number]) {
  * @param array scene的数组
  * @param options
  * @param options.zoomGap number  同步的缩放层级差距
- * @param options.mainSceneIndex number  主场景的数组索引，用于搭配 zoomGap
+ * @param options.mainIndex number  主场景的数组索引，用于搭配 zoomGap
  * @returns Function  清除同步状态的监听函数。
  */
 export function syncScene(
-  array: Instance[],
-  options: {
+  array: Scene[],
+  options?: {
     zoomGap?: number;
-    mainSceneIndex?: number;
+    mainIndex?: number;
   },
 ) {
-  const { zoomGap = 0, mainSceneIndex } = options ?? {};
+  const { zoomGap = 0, mainIndex = 0 } = options ?? {};
   const listeners: any = [];
   let handlers: any = [];
+
+  // 添加地图事件监听
+  const listen = (index: number) => {
+    const scene = array[index];
+    scene.on('mapmove', handlers[index]);
+    scene.on('zoomchange', handlers[index]);
+    return () => {
+      scene.off('mapmove', handlers[index]);
+      scene.off('zoomchange', handlers[index]);
+    };
+  };
+
   const clearListener = () => {
     listeners?.forEach((call: any) => call());
     listeners.length = 0;
   };
-  const handlerSync = (index: number) => {
+
+  // 同步指定索引的scene 地图状态
+  const moveScenePosition = (index: number) => {
     const usedScene = array[index];
     const center = usedScene.getCenter();
     const zoom = usedScene.getZoom();
     array.forEach((item, num) => {
       // 非当前使用scene
       if (num !== index) {
-        if (num === mainSceneIndex) {
+        if (num === mainIndex) {
           // 非主scene
           setZoom(item, zoom - zoomGap);
           setCenter(item, [center.lng, center.lat]);
@@ -75,35 +93,40 @@ export function syncScene(
       }
     });
   };
-  const handler = (index: number) => {
+
+  /**
+   * 地图同步处理器
+   * 1. 清空监听
+   * 2. 同步指定地图状态
+   * 3. 重新初始化地图监听
+   * @param index
+   */
+  const syncHandler = (index: number) => {
     clearListener();
-    handlerSync(index);
+    moveScenePosition(index);
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
     initListener();
   };
 
   const initListener = () => {
     handlers = array.map((value, index) => {
-      return handler.bind(null, index);
+      // 每个地图有自己的状态同步函数
+      return syncHandler.bind(null, index);
     });
     array.forEach((scene, index) => {
-      // eslint-disable-next-line @typescript-eslint/no-use-before-define
+      // 给每个地图绑定监听
       listeners.push(listen(index));
     });
   };
 
-  const listen = (index: number) => {
-    const scene = array[index];
-    scene.on('mapmove', handlers[index]);
-    scene.on('zoomchange', handlers[index]);
-    return () => {
-      scene.off('mapmove', handlers[index]);
-      scene.off('zoomchange', handlers[index]);
-    };
-  };
+  // 初始化,先将所有地图状态同步。
   array.forEach((value, index) => {
-    handlerSync(index);
+    moveScenePosition(index);
   });
+
+  // 添加地图事件监听
   initListener();
+
+  // 返回清除绑定的监听事件函数
   return clearListener;
 }

--- a/src/utils/syncScene.ts
+++ b/src/utils/syncScene.ts
@@ -1,0 +1,109 @@
+/*
+ * @name         : 地图同步方法
+ * @Description  : 用于将多个地图动作、视角同步
+ * @Principle    : 自身发送事件后，解绑自己事件，再重新添加监听
+ */
+
+import type { Scene } from '@antv/l7';
+type Instance = Scene;
+export function getMapType(scene: Scene) {
+  const mapVersion = scene.getMapService().version;
+  return mapVersion?.includes('MAPBOX') ? 'mapbox' : 'gaode';
+}
+
+function setZoom(scene: Scene, zoom: number): void {
+  const mapType = getMapType(scene);
+  if (mapType === 'gaode') {
+    // 高德地图必须关闭动画效果，否则无法实现联动
+    //L7 针对Gao，进行的zoom+ 1 的操作
+    //@ts-ignore
+    scene?.map?.setZoom(zoom + 1, true);
+  } else {
+    //@ts-ignore
+    scene?.map?.setZoom(zoom);
+  }
+}
+
+function setCenter(scene: Scene, center: [number, number]) {
+  const mapType = getMapType(scene);
+  if (mapType === 'gaode') {
+    //@ts-ignore
+    scene?.map.setCenter(center, true);
+  } else {
+    //@ts-ignore
+    scene?.map.setCenter(center);
+  }
+}
+
+/**
+ *
+ * @param array scene的数组
+ * @param options
+ * @param options.zoomGap number  同步的缩放层级差距
+ * @param options.mainSceneIndex number  主场景的数组索引，用于搭配 zoomGap
+ * @returns Function  清除同步状态的监听函数。
+ */
+export function syncScene(
+  array: Instance[],
+  options: {
+    zoomGap?: number;
+    mainSceneIndex?: number;
+  },
+) {
+  const { zoomGap = 0, mainSceneIndex } = options ?? {};
+  const listeners: any = [];
+  let handlers: any = [];
+  const clearListener = () => {
+    listeners?.forEach((call: any) => call());
+    listeners.length = 0;
+  };
+  const handlerSync = (index: number) => {
+    const usedScene = array[index];
+    const center = usedScene.getCenter();
+    const zoom = usedScene.getZoom();
+    array.forEach((item, num) => {
+      // 非当前使用scene
+      if (num !== index) {
+        if (num === mainSceneIndex) {
+          // 非主scene
+          setZoom(item, zoom - zoomGap);
+          setCenter(item, [center.lng, center.lat]);
+        } else {
+          setZoom(item, zoom + zoomGap);
+          setCenter(item, [center.lng, center.lat]);
+        }
+      }
+    });
+  };
+  const handler = (index: number) => {
+    clearListener();
+    handlerSync(index);
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+    initListener();
+  };
+
+  const initListener = () => {
+    handlers = array.map((value, index) => {
+      return handler.bind(null, index);
+    });
+    array.forEach((scene, index) => {
+      // eslint-disable-next-line @typescript-eslint/no-use-before-define
+      listeners.push(listen(index));
+    });
+  };
+
+  const listen = (index: number) => {
+    const scene = array[index];
+    scene.on('mapmove', handlers[index]);
+    scene.on('zoomchange', handlers[index]);
+    return () => {
+      scene.off('mapmove', handlers[index]);
+      scene.off('zoomchange', handlers[index]);
+    };
+  };
+  array.forEach((value, index) => {
+    handlerSync(index);
+  });
+  initListener();
+  return clearListener;
+}

--- a/src/utils/syncScene.ts
+++ b/src/utils/syncScene.ts
@@ -5,6 +5,12 @@
  */
 
 import type { Scene } from '@antv/l7';
+interface GaodeMap {
+  setCenter: (center: [number, number], immediately?: boolean) => void;
+  setZoom: (zoom: number, immediately?: boolean) => void;
+  setRotation: (rotation: number, immediately?: boolean) => void;
+  setPitch: (pitch: number, immediately?: boolean) => void;
+}
 
 // 通过 Scene 获取到地图引擎类型
 function getMapType(scene: Scene) {
@@ -25,19 +31,16 @@ const updateSceneStatus = (
   const mapType = getMapType(scene);
   const { zoom, center, pitch, rotation } = status;
   if (mapType === 'Gaode') {
+    const map = scene?.map as GaodeMap;
     // 高德地图关闭动画效果
-    // @ts-ignore
-    if (center) scene?.map.setCenter(center, true);
-    // @ts-ignore
-    if (zoom) scene?.map?.setZoom(zoom + 1, true);
-    // @ts-ignore
-    if (rotation) scene?.map?.setRotation(rotation, true);
-    // @ts-ignore
-    if (pitch) scene?.map?.setPitch(pitch, true);
+    if (center) map.setCenter(center, true);
+    if (zoom) map?.setZoom(zoom + 1, true);
+    if (rotation) map?.setRotation(360 - rotation, true);
+    if (pitch) map?.setPitch(pitch, true);
   } else {
     if (zoom) scene?.setZoom(zoom);
     if (center) scene?.setCenter(center);
-    if (rotation) scene?.setRotation(rotation);
+    // if (rotation) scene?.setRotation(rotation);
     if (pitch) scene?.setPitch(pitch);
   }
 };
@@ -65,10 +68,16 @@ export function syncScene(
   const listen = (index: number) => {
     const scene = scenes[index];
     scene.on('mapmove', handlers[index]);
+    // Gaode 地图调整倾角和旋转角的事件
+    scene.on('dragging', handlers[index]);
+    // Mapbox 地图调整倾角和旋转角的事件
+    scene.on('drag', handlers[index]);
     scene.on('zoomchange', handlers[index]);
     return () => {
       scene.off('mapmove', handlers[index]);
+      scene.off('dragging', handlers[index]);
       scene.off('zoomchange', handlers[index]);
+      scene.on('drag', handlers[index]);
     };
   };
 

--- a/src/utils/syncScene.ts
+++ b/src/utils/syncScene.ts
@@ -5,6 +5,7 @@
  */
 
 import type { Scene } from '@antv/l7';
+import { isNumber } from 'lodash-es';
 interface GaodeMap {
   setCenter: (center: [number, number], immediately?: boolean) => void;
   setZoom: (zoom: number, immediately?: boolean) => void;
@@ -34,14 +35,14 @@ const updateSceneStatus = (
     const map = scene?.map as GaodeMap;
     // 高德地图关闭动画效果
     if (center) map.setCenter(center, true);
-    if (zoom) map?.setZoom(zoom + 1, true);
-    if (rotation) map?.setRotation(360 - rotation, true);
-    if (pitch) map?.setPitch(pitch, true);
+    if (isNumber(zoom)) map?.setZoom(zoom + 1, true);
+    if (isNumber(rotation)) map?.setRotation(360 - rotation, true);
+    if (isNumber(pitch)) map?.setPitch(pitch, true);
   } else {
-    if (zoom) scene?.setZoom(zoom);
+    if (isNumber(zoom)) scene?.setZoom(zoom);
     if (center) scene?.setCenter(center);
-    if (rotation) scene.setRotation(rotation);
-    if (pitch) scene?.setPitch(pitch);
+    if (isNumber(rotation)) scene.setRotation(rotation);
+    if (isNumber(pitch)) scene?.setPitch(pitch);
   }
 };
 

--- a/src/utils/syncScene.ts
+++ b/src/utils/syncScene.ts
@@ -124,11 +124,10 @@ export function syncScene(
   const syncHandler = (index: number) => {
     clearListener();
     moveScenePosition(index);
-    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     initListener();
   };
 
-  const initListener = () => {
+  function initListener() {
     handlers = scenes.map((value, index) => {
       // 每个地图有自己的状态同步函数
       return syncHandler.bind(null, index);
@@ -137,7 +136,7 @@ export function syncScene(
       // 给每个地图绑定监听
       listeners.push(listen(index));
     });
-  };
+  }
 
   // 初始化,先将所有地图状态同步。
   scenes.forEach((value, index) => {


### PR DESCRIPTION
### 增加地图状态同步方法「syncScene」

+ 新增 ：utils目录下同步地图状态的方法
+ 修改：修改larkmap的index.ts文件，导出utils下增加的同步地图状态方法「syncScene」
+ 新增 ：在docs/example 下的该方法的文档，包括API与示例

### Screenshot


| Before | After |
| ------ | ----- |
| ❌     | ✅    |


### 后续是否考虑类似提供组件方式

```
<div>
<LarkMap ref={instance1} />
<LarkMap ref={instance2} />
<SyncMaps maps={[instance1, instance2]} />
</div>
```
