### PR TITLE
fix: 修复 FlowLayer 和 LayerPopup Demo 中 import 相对路径的问题

### DIFF
--- a/src/components/LayerPopup/demos/default.tsx
+++ b/src/components/LayerPopup/demos/default.tsx
@@ -1,9 +1,8 @@
-import type { LineLayerProps, PolygonLayerProps } from '@antv/larkmap';
+import type { LayerPopupProps, LineLayerProps, PolygonLayerProps } from '@antv/larkmap';
 import { LarkMap, LayerPopup, LineLayer, PolygonLayer } from '@antv/larkmap';
 import type { FeatureCollection } from '@turf/turf';
 import { coordAll, featureCollection, lineString } from '@turf/turf';
 import React, { useEffect, useState } from 'react';
-import type { LayerPopupProps } from '../types';
 
 const polygonLayerOptions: Omit<PolygonLayerProps, 'source'> = {
   autoFit: true,

--- a/src/components/Layers/CompositeLayers/FlowLayer/demos/default.tsx
+++ b/src/components/Layers/CompositeLayers/FlowLayer/demos/default.tsx
@@ -1,6 +1,6 @@
+import type { FlowLayerProps } from '@antv/larkmap';
 import { FlowLayer, LarkMap } from '@antv/larkmap';
 import React, { useEffect, useState } from 'react';
-import type { FlowLayerProps } from '../types';
 
 export default () => {
   const [source, setSource] = useState<FlowLayerProps['source']>({


### PR DESCRIPTION
### PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

- [x] 修复 FlowLayer 和 LayerPopup Demo 中 import 相对路径的问题

### Screenshot

#### Before
<img width="901" alt="image" src="https://github.com/antvis/LarkMap/assets/60083015/d4b83059-2bfe-4380-ac46-0351c5477c29">

#### After
no error
